### PR TITLE
feat: Pre-create BQ tables with partitioning via Terraform

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,127 @@
 locals {
-  # Helper to transform the list of objects into a map keyed by stream_id for for_each
   datastream_map = {
     for config in var.datastream_configs : config.stream_id => config
   }
+
+  // datasets_to_create_map: Identifies datasets to be created and managed by this Terraform configuration,
+  // primarily when bq_dataset_id_prefix is used by a stream configuration.
+  datasets_to_create_map = merge(flatten([
+    for stream_config_key, stream_config_value in local.datastream_map : [
+      if stream_config_value.bq_target_dataset_id == null && stream_config_value.bq_dataset_id_prefix != null : {
+        for pg_schema in stream_config_value.postgres_include_schemas :
+        # Unique key for the dataset resource, combining stream and source schema name
+        format("%s-%s", stream_config_key, pg_schema.schema) => {
+          project_id        = var.project_id
+          dataset_id_short  = format("%s%s", stream_config_value.bq_dataset_id_prefix, pg_schema.schema)
+          location          = stream_config_value.bq_dataset_location
+          stream_config_key_ref = stream_config_key // Reference back to the stream config
+        }
+      } else {} // Empty map if bq_target_dataset_id is set, as these datasets are not "prefix-managed"
+    ]
+  ])...)
+
+  // tables_to_create_flat_map: Creates a flattened map of all BigQuery tables that need to be created.
+  // The key is a unique identifier for each table resource.
+  tables_to_create_flat_map = merge(flatten([
+    for stream_config_key, stream_config_value in local.datastream_map : [
+      for pg_schema in stream_config_value.postgres_include_schemas : [
+        for pg_table in pg_schema.tables : {
+          format("%s-%s-%s", stream_config_key, pg_schema.schema, (pg_table.target_table_name != null ? pg_table.target_table_name : pg_table.table_name)) => {
+            table_resource_project_id      = var.project_id
+            table_resource_dataset_id_short = stream_config_value.bq_target_dataset_id != null ?
+                                              stream_config_value.bq_target_dataset_id :
+                                              format("%s%s", stream_config_value.bq_dataset_id_prefix, pg_schema.schema)
+            table_resource_table_id        = (pg_table.target_table_name != null ? pg_table.target_table_name : pg_table.table_name)
+            table_resource_schema_fields   = pg_table.schema_fields
+            table_resource_time_partitioning = pg_table.time_partitioning
+            table_resource_clustering_fields = pg_table.clustering_fields
+            stream_id_ref                  = stream_config_key // Used for depends_on in the stream resource
+          }
+        }
+      ]
+    ]
+  ])...)
+
+  target_dataset_ids_map = {
+    for stream_cfg in var.datastream_configs :
+    stream_cfg.bq_target_dataset_id => {
+      project_id = var.project_id
+      dataset_id = stream_cfg.bq_target_dataset_id
+    } if stream_cfg.bq_target_dataset_id != null
+  }
+}
+
+# Create BigQuery Datasets if using prefix-based naming (source hierarchy mode)
+resource "google_bigquery_dataset" "managed_pg_schema_datasets" {
+  for_each = local.datasets_to_create_map
+
+  project_id                  = each.value.project_id
+  dataset_id                  = each.value.dataset_id_short
+  location                    = each.value.location
+  delete_contents_on_destroy  = true # REVIEW: Set to false for production
+
+  labels = {
+    "created_by"  = "terraform-datastream-module"
+    "stream_id"   = each.value.stream_config_key_ref
+    "source_schema" = split("-", each.key)[1] # Extracts source schema from the map key (e.g. stream1-public -> public)
+  }
+}
+
+# Data source to validate existence of externally managed target datasets
+data "google_bigquery_dataset" "referenced_target_datasets" {
+  for_each = local.target_dataset_ids_map
+
+  project_id = each.value.project_id
+  dataset_id = each.value.dataset_id
+
+  # This data source will fail if the dataset does not exist,
+  # ensuring that streams targeting an explicit bq_target_dataset_id
+  # are pointing to a valid, existing dataset.
+}
+
+resource "google_bigquery_table" "all_tables" {
+  for_each = local.tables_to_create_flat_map
+
+  project    = each.value.table_resource_project_id
+  dataset_id = each.value.table_resource_dataset_id_short # This correctly uses the short dataset ID
+  table_id   = each.value.table_resource_table_id
+
+  # Schema must be a JSON string
+  schema = jsonencode(each.value.table_resource_schema_fields)
+
+  dynamic "time_partitioning" {
+    for_each = each.value.table_resource_time_partitioning != null ? [each.value.table_resource_time_partitioning] : []
+    content {
+      type                       = time_partitioning.value.type
+      field                      = time_partitioning.value.field
+      expiration_ms              = lookup(time_partitioning.value, "expiration_ms", null)
+      require_partition_filter   = lookup(time_partitioning.value, "require_partition_filter", false)
+    }
+  }
+
+  clustering = each.value.table_resource_clustering_fields # This should be a list of strings
+
+  deletion_protection = false # REVIEW: Set to true for production tables if needed
+
+  labels = {
+    "created_by"  = "terraform-datastream-module"
+    "stream_id"   = each.value.stream_id_ref
+    "source_table_name" = split("-", each.key)[2] # Extracts original source table name from map key (e.g. stream1-public-orders -> orders)
+  }
+
+  # Ensure tables depend on their respective datasets if those datasets are managed by this config.
+  # This is implicitly handled if dataset_id refers to a dataset created here,
+  # but explicit depends_on can be added if complex inter-dependencies arise with dataset creation logic.
+  # For datasets referenced via `data.google_bigquery_dataset.referenced_target_datasets`,
+  # their existence is checked by the data source. If a dataset from `local.datasets_to_create_map`
+  # matches `each.value.table_resource_dataset_id_short`, Terraform creates the dependency.
 }
 
 resource "google_datastream_stream" "streams" {
   for_each = local.datastream_map
 
-  provider     = google-beta # Ensure you are using a provider alias that supports Datastream if necessary
-  project      = var.project_id # Assuming you have a project_id variable defined elsewhere
+  provider     = google-beta
+  project      = var.project_id
   location     = each.value.location
   stream_id    = each.value.stream_id
   display_name = each.value.display_name
@@ -19,33 +131,32 @@ resource "google_datastream_stream" "streams" {
     postgresql_source_config {
       include_objects {
         dynamic "postgresql_schemas" {
-          for_each = each.value.postgres_include_schemas
+          for_each = each.value.postgres_include_schemas # This is list(object({schema=string, tables=list(object({table_name=string, ...}))}))
+          iterator = pg_schema_config
           content {
-            schema = postgresql_schemas.value.schema
+            schema = pg_schema_config.value.schema
             dynamic "postgresql_tables" {
-              for_each = postgresql_schemas.value.tables
+              for_each = pg_schema_config.value.tables
+              iterator = pg_table_config
               content {
-                table   = postgresql_tables.value.table_name
-                dynamic "postgresql_columns" {
-                  for_each = postgresql_tables.value.columns != null ? postgresql_tables.value.columns : []
-                  content {
-                    column = postgresql_columns.value
-                  }
-                }
+                table   = pg_table_config.value.table_name
+                columns = pg_table_config.value.columns
               }
             }
           }
         }
       }
-      dynamic "exclude_objects" {
+      dynamic "exclude_objects" { # Assuming var.datastream_configs.postgres_exclude_objects is list(object({schema=string, tables=list(string)}))
         for_each = each.value.postgres_exclude_objects != null ? each.value.postgres_exclude_objects : []
+        iterator = exclude_config_item
         content {
           postgresql_schemas {
-            schema = exclude_objects.value.schema
+            schema = exclude_config_item.value.schema
             dynamic "postgresql_tables" {
-              for_each = exclude_objects.value.tables != null ? exclude_objects.value.tables : []
+              for_each = exclude_config_item.value.tables # Assumes tables is a list of strings
+              iterator = excluded_table_name_iterator
               content {
-                table = postgresql_tables.value
+                table = excluded_table_name_iterator.value
               }
             }
           }
@@ -59,20 +170,29 @@ resource "google_datastream_stream" "streams" {
   destination_config {
     destination_connection_profile = each.value.destination_connection_profile
     bigquery_destination_config {
-      source_hierarchy_datasets {
-        dataset_template {
-          location       = each.value.bq_dataset_location
-          dataset_id_prefix = each.value.bq_dataset_id_prefix
+      dynamic "single_target_dataset" {
+        for_each = each.value.bq_target_dataset_id != null ? [each.value.bq_target_dataset_id] : []
+        iterator = bq_target_ds_id_iterator # Use an iterator here
+        content {
+          dataset_id = data.google_bigquery_dataset.referenced_target_datasets[bq_target_ds_id_iterator.value].id
         }
       }
-      data_freshness = each.value.bq_data_freshness // Example: 15 minutes, adjust as needed
+      dynamic "source_hierarchy_datasets" {
+        for_each = each.value.bq_target_dataset_id == null ? [1] : []
+        content {
+          dataset_template {
+            location          = each.value.bq_dataset_location
+            dataset_id_prefix = each.value.bq_dataset_id_prefix
+          }
+        }
+      }
+      data_freshness = each.value.bq_data_freshness
     }
   }
 
   dynamic "backfill_all" {
     for_each = each.value.backfill_strategy == "all" ? [1] : []
-    content {
-    }
+    content {}
   }
 
   dynamic "backfill_none" {
@@ -81,4 +201,9 @@ resource "google_datastream_stream" "streams" {
   }
 
   desired_state = each.value.run_immediately ? "RUNNING" : "NOT_STARTED"
+
+  depends_on = [
+    for k, v in local.tables_to_create_flat_map :
+    google_bigquery_table.all_tables[k] if v.stream_id_ref == each.key
+  ]
 }

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,79 +1,153 @@
 # Example for datastream_configs variable
 # Remove this comment and uncomment the block below to use.
-# Ensure project_id, publication_name, and replication_slot_name are also defined in your actual .tfvars file or elsewhere.
+# Ensure project_id is also defined in your actual .tfvars file.
 
 /*
 project_id = "your-gcp-project-id"
-// publication_name and replication_slot_name are now per-stream
 
 datastream_configs = [
   {
+    # Stream 1: Uses a single target dataset (bq_target_dataset_id)
+    # Tables 'orders' and 'customers' from the 'sales' schema will be created in 'sales_destination_dataset'.
     stream_id                  = "pg-to-bq-stream-01"
     display_name               = "PostgreSQL to BigQuery Stream 1 (Sales Data)"
     location                   = "us-central1"
     source_connection_profile  = "projects/your-gcp-project-id/locations/us-central1/connectionProfiles/pg-source-profile-example"
     destination_connection_profile = "projects/your-gcp-project-id/locations/us-central1/connectionProfiles/bq-destination-profile-example"
-    publication_name               = "your_pg_publication_for_stream_1",
-    replication_slot_name          = "your_pg_slot_for_stream_1",
+    publication_name               = "pg_publication_sales"
+    replication_slot_name          = "pg_slot_sales"
 
     postgres_include_schemas = [
       {
-        schema = "sales",
+        schema = "sales", # Source PostgreSQL schema
         tables = [
           {
-            table_name = "orders",
-            columns    = ["order_id", "customer_id", "order_date", "total_amount"]
+            table_name = "orders",                                       # Source PostgreSQL table name
+            columns    = ["order_id", "customer_id", "order_date", "total_amount"], # Optional: Source columns to include. Empty or null means all columns.
+            target_table_name = "bq_orders_table",                     # Optional: Target BQ table name. Defaults to source 'table_name' if omitted.
+            schema_fields = [                                          # Required: BigQuery schema definition for the target table.
+              { name = "order_id", type = "INTEGER", mode = "REQUIRED", description = "Primary key for orders" },
+              { name = "customer_id", type = "INTEGER", description = "Foreign key to customers table" },
+              { name = "order_date", type = "TIMESTAMP", description = "Timestamp of the order" },
+              { name = "total_amount", type = "NUMERIC", description = "Total amount of the order" }
+              # Datastream metadata columns (e.g., uuid, source_timestamp) are typically added by Datastream.
+              # Define them here if you need to customize their type/mode or ensure they are part of the Terraform-managed schema.
+            ],
+            time_partitioning = {                                      # Optional: BigQuery time partitioning configuration.
+              type  = "DAY"                                            # Partitioning type (e.g., DAY, HOUR, MONTH, YEAR).
+              field = "order_date"                                     # The BQ field for partitioning (must be TIMESTAMP or DATE type in schema_fields).
+              require_partition_filter = true                          # Optional: Require partition filter for queries. Defaults to false.
+              # expiration_ms = null                                   # Optional: Partition expiration in milliseconds.
+            },
+            clustering_fields = ["customer_id"]                        # Optional: List of fields for BigQuery clustering.
           },
           {
-            table_name = "customers" # All columns from customers table
+            table_name = "customers",                                  # Source PostgreSQL table name
+            # columns = null,                                          # Example: All columns from source 'customers' table.
+            target_table_name = "bq_customers_table",
+            schema_fields = [
+              { name = "customer_id", type = "INTEGER", mode = "REQUIRED" },
+              { name = "customer_name", type = "STRING" },
+              { name = "email", type = "STRING" },
+              { name = "registration_date", type = "DATE" }
+            ],
+            time_partitioning = null,                                  # Example: No time partitioning for this table.
+            clustering_fields = ["customer_name"]
           }
         ]
       },
       {
-        schema = "inventory" # All tables and columns from inventory schema
+        schema = "inventory", # Source PostgreSQL schema
+        tables = [
+          {
+            table_name = "products",
+            schema_fields = [
+              { name = "product_id", type = "INTEGER", mode = "REQUIRED" },
+              { name = "product_name", type = "STRING" },
+              { name = "category", type = "STRING" },
+              { name = "price", type = "NUMERIC" }
+            ]
+            # No time_partitioning or clustering_fields specified, so table will be standard.
+          }
+        ]
+        # This entire schema 'inventory' and its tables will be part of the 'sales_destination_dataset'.
       }
     ]
 
-    postgres_exclude_objects = [
+    postgres_exclude_objects = [ # Optional: Objects to exclude from the stream.
       {
         schema = "sales",
-        tables = ["temporary_orders_archive"] # Exclude specific table from sales schema
+        tables = ["temporary_orders_archive"] # List of table names (strings) to exclude from this schema.
       }
     ]
 
-    bq_dataset_id_prefix = "sales_stream_"
-    bq_dataset_location  = "US"
-    backfill_strategy    = "all"
-    create_paused        = false
+    # BigQuery Destination Configuration for Stream 1
+    bq_target_dataset_id = "sales_destination_dataset" # All tables from this stream go here. Dataset should ideally exist or be managed by a separate BQ TF config if shared.
+                                                       # If this Terraform creates it due to other streams using prefix mode for the same dataset name, that's also possible.
+    # bq_dataset_id_prefix = null, # Ignored because bq_target_dataset_id is set.
+    bq_dataset_location  = "US", # Primarily used if bq_target_dataset_id is null and bq_dataset_id_prefix is active.
+                                 # If bq_target_dataset_id is set, this location should match the target dataset's location.
+    bq_data_freshness    = "900s", # 15 minutes
+    backfill_strategy    = "all",  # or "none"
+    run_immediately      = true
   },
+
   {
+    # Stream 2: Uses bq_dataset_id_prefix (source hierarchy mode).
+    # Datasets like "mktg_stream_marketing" will be created by this Terraform.
+    # Tables 'campaigns' and 'leads' from 'marketing' schema will be in 'mktg_stream_marketing'.
     stream_id                  = "pg-to-bq-stream-02"
-    display_name               = "PostgreSQL to BigQuery Stream 2 (Marketing Data - No Backfill)"
+    display_name               = "PostgreSQL to BigQuery Stream 2 (Marketing - Source Hierarchy)"
     location                   = "us-east1"
     source_connection_profile  = "projects/your-gcp-project-id/locations/us-east1/connectionProfiles/pg-source-profile-marketing"
     destination_connection_profile = "projects/your-gcp-project-id/locations/us-east1/connectionProfiles/bq-destination-profile-marketing"
-    publication_name               = "your_pg_publication_for_stream_2",
-    replication_slot_name          = "your_pg_slot_for_stream_2",
+    publication_name               = "pg_publication_marketing"
+    replication_slot_name          = "pg_slot_marketing"
 
     postgres_include_schemas = [
       {
-        schema = "marketing",
+        schema = "marketing", # Source PostgreSQL schema name
         tables = [
           {
-            table_name = "campaigns"
+            table_name = "campaigns", # Source table name. Target BQ table will be 'campaigns'.
+            schema_fields = [
+              { name = "campaign_id", type = "INTEGER", mode = "REQUIRED" },
+              { name = "campaign_name", type = "STRING" },
+              { name = "start_date", type = "DATE" },
+              { name = "end_date", type = "DATE" },
+              { name = "budget", type = "NUMERIC" }
+            ],
+            time_partitioning = {
+              type  = "MONTH",
+              field = "start_date" # This BQ field must exist in schema_fields with DATE or TIMESTAMP type.
+            }
+            # clustering_fields = null # Example: No clustering for this table.
           },
           {
-            table_name = "leads"
+            table_name = "leads",
+            schema_fields = [
+              { name = "lead_id", type = "INTEGER", mode = "REQUIRED" },
+              { name = "campaign_id", type = "INTEGER" },
+              { name = "lead_source", type = "STRING" },
+              { name = "conversion_date", type = "TIMESTAMP" }
+            ],
+            time_partitioning = {
+              type  = "DAY",
+              field = "conversion_date"
+            }
           }
         ]
       }
     ]
-    // No postgres_exclude_objects for this stream, so it's omitted (optional)
+    # postgres_exclude_objects = null, # Optional: No specific excludes for this stream.
 
-    bq_dataset_id_prefix = "mktg_stream_"
-    bq_dataset_location  = "US"
-    backfill_strategy    = "none" # No backfill for this stream
-    create_paused        = true   # Create this stream in a paused state
+    # BigQuery Destination Configuration for Stream 2
+    bq_target_dataset_id = null # Set to null to enable source hierarchy mode.
+    bq_dataset_id_prefix = "mktg_stream_" # Datasets like "mktg_stream_marketing" will be created.
+    bq_dataset_location  = "US"   # Location for these dynamically created datasets.
+    bq_data_freshness    = "1800s", # 30 minutes
+    backfill_strategy    = "none",
+    run_immediately      = false
   }
 ]
 */

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,5 @@
-variable "project_id" {
-  description = "GCP Project ID"
-  type = string
-}
-
 variable "datastream_configs" {
-  description = "Configuration for multiple Datastream streams from PostgreSQL to BigQuery."
+  description = "Configuration for multiple Datastream streams from PostgreSQL to BigQuery. Includes definitions for source objects and corresponding target BigQuery table schemas and configurations."
   type = list(object({
     stream_id          = string
     display_name       = string
@@ -18,8 +13,22 @@ variable "datastream_configs" {
     postgres_include_schemas = list(object({
       schema = string // Schema name
       tables = optional(list(object({ // Tables to include from this schema. If empty/omitted, all tables from this schema are included.
-        table_name = string // Table name
-        columns    = optional(list(string)) // Specific column names to include. If empty/omitted, all columns from this table are included.
+        table_name        = string // Source PostgreSQL table name
+        columns           = optional(list(string)) // Specific source columns to include. If empty/omitted, all columns.
+        target_table_name = optional(string)     // Optional: Name of the target BigQuery table. Defaults to source table_name if not specified.
+        schema_fields     = list(object({      // Required: BigQuery schema definition for the target table.
+          name = string
+          type = string
+          mode = optional(string, "NULLABLE")
+          description = optional(string)
+        }))
+        time_partitioning = optional(object({   // Optional: BigQuery time partitioning configuration.
+          type                       = string // e.g., "DAY", "HOUR", "MONTH", "YEAR"
+          field                      = string // The field to use for partitioning.
+          expiration_ms              = optional(number)
+          require_partition_filter   = optional(bool, false)
+        }), null)
+        clustering_fields = optional(list(string), null) // Optional: List of fields for BigQuery clustering.
       })), [])
     }))
 
@@ -30,10 +39,11 @@ variable "datastream_configs" {
     })), [])
 
     // BigQuery destination specific details
-    bq_dataset_id_prefix = string // Prefix for dataset IDs in BigQuery that Datastream will create/use, e.g., "pg_stream_"
+    bq_dataset_id_prefix = string // Prefix for dataset IDs in BigQuery that Datastream will create/use, e.g., "pg_stream_". Not used if bq_target_dataset_id is set for a stream.
+    bq_target_dataset_id = optional(string, null) // The ID of the single BigQuery dataset where all tables from this stream will be created. If specified, `bq_dataset_id_prefix` is ignored.
     
     bq_dataset_location  = string // Location for BQ datasets (used in source_hierarchy_datasets.dataset_template.location), e.g., "US"
-    bq_data_freshness = optional(string, "900s") //Data Freshness for BQ, default to 900s 
+    bq_data_freshness = optional(string, "900s") //Data Freshness for BQ, default to 900s
     // Stream behavior
     backfill_strategy = optional(string, "all") // Valid values: "all" or "none". Determines if backfill_all {} or backfill_none {} is set.
     run_immediately     = optional(bool, false)   // If true, stream is created with desired_state = "PAUSED". Default is "RUNNING".


### PR DESCRIPTION
This commit implements a robust solution for streaming PostgreSQL data to partitioned and clustered BigQuery tables using Datastream, by pre-creating the BigQuery tables with the desired configuration directly within Terraform.

This approach addresses the limitation that Datastream itself does not manage partitioning or clustering when it creates tables.

Key changes:

1.  **Enhanced `variables.tf`**:
    *   The `datastream_configs.postgres_include_schemas.tables` object
        has been significantly updated. It now accepts detailed BigQuery
        table definitions, including:
        *   `target_table_name` (optional)
        *   `schema_fields` (list of BQ column definitions - required)
        *   `time_partitioning` (optional object for BQ time partitioning)
        *   `clustering_fields` (optional list for BQ clustering)

2.  **Modified `main.tf`**:
    *   Added `google_bigquery_dataset` resources: Datasets are now
        explicitly managed by Terraform. If `bq_target_dataset_id` is
        provided, a data source is used to reference it. If
        `bq_dataset_id_prefix` is used, datasets are created per
        source schema.
    *   Added `google_bigquery_table` resources: For each table specified
        in `datastream_configs`, a corresponding BigQuery table is created
        with its defined schema, partitioning, and clustering.
    *   Updated `google_datastream_stream` resources:
        *   These now `depends_on` the created `google_bigquery_table`
            resources, ensuring tables exist before streaming begins.
        *   Destination configuration points to these pre-created tables.

3.  **Updated `terraform.tfvars.example`**:
    *   The example file has been extensively updated to demonstrate the
        new, more detailed configuration for `datastream_configs`,
        showcasing how to define schemas, partitioning, and clustering
        for target BigQuery tables.

This approach ensures that BigQuery tables are structured correctly (partitioned and clustered) before Datastream starts delivering data, automating the entire setup via Terraform in a declarative way.